### PR TITLE
[MRG] Includes head of file in notebook (01)

### DIFF
--- a/notebooks/01 - Data Loading.ipynb
+++ b/notebooks/01 - Data Loading.ipynb
@@ -185,7 +185,15 @@
     "import os\n",
     "iris_path = os.path.join(sklearn.datasets.__path__[0], 'data', 'iris.csv')\n",
     "```\n",
-    "Load the data from there using pandas ``pd.read_csv`` method and bring it into the same format as before with the data in a variable X and the labels in a variable y. After defining ``iris_path``, the beginning of the file can be viewed by running: ``!head $iris_path``"
+    "Load the data from there using pandas ``pd.read_csv`` method and bring it into the same format as before with the data in a variable X and the labels in a variable y. The first few lines of ``iris.csv`` file looks like:\n",
+    "\n",
+    "```\n",
+    "150,4,setosa,versicolor,virginica\n",
+    "5.1,3.5,1.4,0.2,0\n",
+    "4.9,3.0,1.4,0.2,0\n",
+    "4.7,3.2,1.3,0.2,0\n",
+    "4.6,3.1,1.5,0.2,0\n",
+    "```"
    ]
   },
   {


### PR DESCRIPTION
Bash command would not work on windows, this PR adds the head of `iris.csv` directly into the notebook. (Makes it easier to focus on the `pd.read_csv` api)