### PR TITLE
Fix typo in the magic line within the `03 - Preprocessing` notebook

### DIFF
--- a/notebooks/03 - Preprocessing.ipynb
+++ b/notebooks/03 - Preprocessing.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "% matplotlib inline"
+    "%matplotlib inline"
    ]
   },
   {


### PR DESCRIPTION
Hi @amueller , during reviewing of the material of this course i found one typo. The typo is within the `%matplotlib inline`magic line inside the `03 - Preprocessing` notebook.

This PR fixes the issue.

Cheers, Daniel